### PR TITLE
Reduce cloning in write_object_entry

### DIFF
--- a/crates/sui-core/src/execution_cache/writeback_cache.rs
+++ b/crates/sui-core/src/execution_cache/writeback_cache.rs
@@ -37,6 +37,7 @@
 //!
 //! The above design is used for both objects and markers.
 
+use crate::authority::AuthorityStore;
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use crate::authority::authority_store::{
     ExecutionLockWriteGuard, LockDetailsDeprecated, ObjectLockStatus, SuiLockResult,
@@ -44,14 +45,13 @@ use crate::authority::authority_store::{
 use crate::authority::authority_store_tables::LiveObject;
 use crate::authority::backpressure::BackpressureManager;
 use crate::authority::epoch_start_configuration::{EpochFlag, EpochStartConfiguration};
-use crate::authority::AuthorityStore;
 use crate::fallback_fetch::{do_fallback_lookup, do_fallback_lookup_fallible};
 use crate::global_state_hasher::GlobalStateHashStore;
 use crate::transaction_outputs::TransactionOutputs;
 
-use dashmap::mapref::entry::Entry as DashMapEntry;
 use dashmap::DashMap;
-use futures::{future::BoxFuture, FutureExt};
+use dashmap::mapref::entry::Entry as DashMapEntry;
+use futures::{FutureExt, future::BoxFuture};
 use moka::sync::SegmentedCache as MokaCache;
 use mysten_common::debug_fatal;
 use mysten_common::random_util::randomize_cache_capacity_in_tests;
@@ -59,8 +59,8 @@ use mysten_common::sync::notify_read::NotifyRead;
 use parking_lot::Mutex;
 use std::collections::{BTreeMap, HashSet};
 use std::hash::Hash;
-use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
 use sui_config::ExecutionCacheConfig;
 use sui_macros::fail_point;
 use sui_protocol_config::ProtocolVersion;
@@ -68,7 +68,7 @@ use sui_types::accumulator_event::AccumulatorEvent;
 use sui_types::base_types::{
     EpochId, FullObjectID, ObjectID, ObjectRef, SequenceNumber, VerifiedExecutionData,
 };
-use sui_types::bridge::{get_bridge, Bridge};
+use sui_types::bridge::{Bridge, get_bridge};
 use sui_types::digests::{ObjectDigest, TransactionDigest, TransactionEffectsDigest};
 use sui_types::effects::{TransactionEffects, TransactionEvents};
 use sui_types::error::{SuiError, SuiResult, UserInputError};
@@ -80,19 +80,19 @@ use sui_types::object::Object;
 use sui_types::storage::{
     FullObjectKey, InputKey, MarkerValue, ObjectKey, ObjectOrTombstone, ObjectStore, PackageObject,
 };
-use sui_types::sui_system_state::{get_sui_system_state, SuiSystemState};
+use sui_types::sui_system_state::{SuiSystemState, get_sui_system_state};
 use sui_types::transaction::{TransactionDataAPI, VerifiedSignedTransaction, VerifiedTransaction};
 use tap::TapOptional;
 use tracing::{debug, info, instrument, trace, warn};
 
-use super::cache_types::Ticket;
 use super::ExecutionCacheAPI;
+use super::cache_types::Ticket;
 use super::{
+    Batch, CheckpointCache, ExecutionCacheCommit, ExecutionCacheMetrics, ExecutionCacheReconfigAPI,
+    ExecutionCacheWrite, ObjectCacheRead, StateSyncAPI, TestingAPI, TransactionCacheRead,
     cache_types::{CacheResult, CachedVersionMap, IsNewer, MonotonicCache},
     implement_passthrough_traits,
     object_locks::ObjectLocks,
-    Batch, CheckpointCache, ExecutionCacheCommit, ExecutionCacheMetrics, ExecutionCacheReconfigAPI,
-    ExecutionCacheWrite, ObjectCacheRead, StateSyncAPI, TestingAPI, TransactionCacheRead,
 };
 
 #[cfg(test)]
@@ -574,31 +574,37 @@ impl WritebackCache {
         //   the tx finalizer, plus checkpoint executor, consensus, and RPCs from fullnodes.
         let mut entry = self.dirty.objects.entry(*object_id).or_default();
 
+        let notify_key = if let ObjectEntry::Object(object) = &object {
+            if object.is_package() {
+                Some(InputKey::Package { id: *object_id })
+            } else if !object.is_child_object() {
+                Some(InputKey::VersionedObject {
+                    id: object.full_id(),
+                    version: object.version(),
+                })
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        let cache_object = object.clone();
+
+        entry.insert(version, object);
+
         self.object_by_id_cache
             .insert(
                 object_id,
-                LatestObjectCacheEntry::Object(version, object.clone()),
+                LatestObjectCacheEntry::Object(version, cache_object),
                 Ticket::Write,
             )
             // While Ticket::Write cannot expire, this insert may still fail.
             // See the comment in `MonotonicCache::insert`.
             .ok();
 
-        entry.insert(version, object.clone());
-
-        if let ObjectEntry::Object(object) = &object {
-            if object.is_package() {
-                self.object_notify_read
-                    .notify(&InputKey::Package { id: *object_id }, &());
-            } else if !object.is_child_object() {
-                self.object_notify_read.notify(
-                    &InputKey::VersionedObject {
-                        id: object.full_id(),
-                        version: object.version(),
-                    },
-                    &(),
-                );
-            }
+        if let Some(key) = notify_key {
+            self.object_notify_read.notify(&key, &());
         }
     }
 
@@ -1049,11 +1055,12 @@ impl WritebackCache {
             mysten_metrics::monitored_scope("WritebackCache::commit_transaction_outputs::flush");
         for outputs in all_outputs.iter() {
             let tx_digest = outputs.transaction.digest();
-            assert!(self
-                .dirty
-                .pending_transaction_writes
-                .remove(tx_digest)
-                .is_some());
+            assert!(
+                self.dirty
+                    .pending_transaction_writes
+                    .remove(tx_digest)
+                    .is_some()
+            );
             self.flush_transactions_from_dirty_to_cached(epoch, *tx_digest, outputs);
         }
 


### PR DESCRIPTION
## Summary
- Avoid double cloning in `write_object_entry` by moving the object into the dirty map and cloning only for the latest cache
- Precompute notification key before consuming the object

## Testing
- `cargo test -p sui-core writeback_cache_tests -- --quiet` *(fails: build terminated due to time constraints)*

------
https://chatgpt.com/codex/tasks/task_e_68a9029efdc8832091fe6b96cdaea3f4